### PR TITLE
Add support for Python 3.2 and 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 from setuptools import setup
 from os import path
+from sys import version_info
 
+py_version = version_info[:2]
+
+if py_version < (2, 6):
+    raise RuntimeError(
+        'On Python 2, supervisor-wildcards requires Python 2.6 or later')
+elif (3, 0) < py_version < (3, 2):
+    raise RuntimeError(
+        'On Python 3, supervisor-wildcards requires Python 3.2 or later')
 
 VERSION = (0, 1, 3)
 __version__ = VERSION
@@ -29,6 +38,11 @@ setup(
         "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
     ],

--- a/test_supervisorwildcards/supervisord_multi.py
+++ b/test_supervisorwildcards/supervisord_multi.py
@@ -11,9 +11,9 @@ def main():
         while True:
             time.sleep(10)
     except KeyboardInterrupt:
-        print 'stoping..'
+        print('stopping..')
         test_dashvisor.tearDown()
-        print 'stoped'
+        print('stopped')
 
 
 if __name__ == '__main__':

--- a/test_supervisorwildcards/test_plugin.py
+++ b/test_supervisorwildcards/test_plugin.py
@@ -15,8 +15,9 @@ class TestPlugin(TestCase):
         self._supervisorctl('start all')
 
     def _supervisorctl(self, cmd, config_file=CONFIG_FILE):
-        out = Popen('supervisorctl --configuration="%s" %s' % (config_file, cmd), shell=True, stdout=PIPE).stdout.read()
-        print out
+        c = 'supervisorctl --configuration="%s" %s' % (config_file, cmd)
+        out = Popen(c, shell=True, stdout=PIPE).stdout.read().decode("utf-8")
+        print(out)
         return out
 
     def assert_status(self, expected):


### PR DESCRIPTION
There is now a branch of Supervisor that supports Python 2 and 3.  It is planned to be the next major release version.  After these changes, the supervisor-wildcards tests pass on Python 3.  
